### PR TITLE
Use original name for `UA_EMPTY_ARRAY_SENTINEL` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Breaking: Rename `UA_EMPTY_ARRAY_SENTINEL_` back to `UA_EMPTY_ARRAY_SENTINEL` without trailing
+  underscore.
+
 ## [0.1.3] - 2024-01-12
 
 [0.1.3]: https://github.com/HMIProject/open62541-sys/releases/tag/v0.1.3

--- a/build.rs
+++ b/build.rs
@@ -40,9 +40,9 @@ fn main() {
         // declaration they belong to.
         .generate_comments(false)
         .header(input.to_string_lossy())
-        // Make cargo invalidate the generated bindings whenever any of the files included from the
-        // header change.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // Activate parse callbacks. This causes cargo to invalidate the generated bindings when any
+        // of the included files change. It also enables us to rename items in the final bindings.
+        .parse_callbacks(Box::new(CustomCallbacks))
         // We may use `core` instead of `std`. This might be useful for `no_std` environments.
         .use_core()
         // Wrap static functions. These are used in several places for inline helpers and we want to
@@ -73,4 +73,32 @@ fn main() {
         .flag_if_supported("-Wno-deprecated-declarations")
         .flag_if_supported("-Wno-deprecated")
         .compile(ext_name);
+}
+
+#[derive(Debug)]
+struct CustomCallbacks;
+
+// Include `cargo:rerun-if` instructions just like `bindgen::CargoCallbacks` does. In addition, make
+// necessary adjustments to the names of items for the final bindings.
+impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {
+    fn header_file(&self, filename: &str) {
+        // Make sure to rerun build when header file changes.
+        println!("cargo:rerun-if-changed={}", filename);
+    }
+
+    fn include_file(&self, filename: &str) {
+        // Make sure to rerun build when include file changes.
+        println!("cargo:rerun-if-changed={}", filename);
+    }
+
+    fn read_env_var(&self, key: &str) {
+        // Make sure to rerun build when environment variable changes.
+        println!("cargo:rerun-if-env-changed={}", key);
+    }
+
+    fn item_name(&self, original_item_name: &str) -> Option<String> {
+        // Rename pointer constant back to its original name. See `wrapper.c` for details.
+        (original_item_name == "UA_EMPTY_ARRAY_SENTINEL_")
+            .then(|| "UA_EMPTY_ARRAY_SENTINEL".to_owned())
+    }
 }


### PR DESCRIPTION
## Description

This uses parse callbacks to adjust the name of `UA_EMPTY_ARRAY_SENTINEL` back to its proper name without trailing underscore.

The reason we had an underscore in the first place was that we needed (and still need) to define a static constant to let bindgen define what in the original code is a non-trivial macro.