### PR TITLE
Add binding of `vsnprintf()` to use for formatting log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Include binding for `vsnprintf()` from `stdio.h` to simplify formatting of log messages.
+
 ## [0.1.3] - 2024-01-12
 
 [0.1.3]: https://github.com/HMIProject/open62541-sys/releases/tag/v0.1.3

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,8 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .allowlist_function("(__)?UA_.*")
+        // Include `vsnprintf()` from `stdio.h` to simplify formatting of log messages.
+        .allowlist_function("vsnprintf")
         .allowlist_type("(__)?UA_.*")
         .allowlist_var("(__)?UA_.*")
         .clang_arg(format!("-I{}", dst.join("include").display()))

--- a/wrapper.h
+++ b/wrapper.h
@@ -6,6 +6,8 @@
 #include <open62541/client_highlevel_async.h>
 #include <open62541/client_subscriptions.h>
 #include <open62541/plugin/log_stdout.h>
+// Include with binding of `vsnprintf()` to simplify formatting of log messages.
+#include <stdio.h>
 
 // bindgen does not support non-trivial `#define` used for pointer constant. Use
 // statically defined constant as workaround for now.


### PR DESCRIPTION
## Description

For HMIProject/open62541#22 we need to pass back control to C string formatting with `vprintf` et al. For this, we include the bounds-checked string variant `vsnprintf()` in the generated bindings. It is available via `<stdio.h>` anyway and does not increase the size of the resulting library.