### PR TITLE
Add wrapper for `vsnprintf()` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Add wrapper for `vsnprintf()` to support older C library versions (before UCRT in Visual Studio
+  2015 and Windows 10).
+
 ## [0.2.0] - 2024-01-17
 
 [0.2.0]: https://github.com/HMIProject/open62541-sys/compare/v0.1.3...v0.2.0

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use core::{ffi, ptr};
 
 use open62541_sys::{
-    va_list_, UA_Client_delete, UA_Client_new, UA_LogCategory, UA_LogLevel, UA_Logger,
+    va_list_, vsnprintf, UA_Client_delete, UA_Client_new, UA_LogCategory, UA_LogLevel, UA_Logger,
     UA_LoggerClearCallback_, UA_LoggerLogCallback_,
 };
 
@@ -48,4 +48,12 @@ fn logger_types() {
         context: ptr::null_mut(),
         clear,
     };
+}
+
+#[test]
+fn has_vsnprintf() {
+    // Make sure that `vsnprintf()` is available. On Microsoft Windows we have to provide a wrapper,
+    // to support older versions of the C library (before the introduction of the UCRT/Visual Studio
+    // 2015/Windows 10).
+    let _unused = vsnprintf;
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -1,7 +1,39 @@
-#include <open62541/types.h>
+#include "wrapper.h"
+
+// Wrapper for `vsnprintf()` with normalized behavior across different platforms
+// such as Microsoft Windows.
+#if defined(_MSC_VER) && _MSC_VER < 1900
+int RS_vsnprintf(
+    char *buffer,
+    size_t count,
+    const char *format,
+    va_list argptr)
+{
+  // Microsoft does not (always) define a standard-conforming `vsnprintf()`. But
+  // it does define a variant with slightly different behavior. We normalize the
+  // differences as best we can.
+  int result = -1;
+  if (count)
+    result = _vsnprintf_s(buffer, count, _TRUNCATE, format, argptr);
+  if (result < 0)
+    result = _vscprintf(format, argptr);
+  return result;
+}
+#else
+int RS_vsnprintf(
+    char *buffer,
+    size_t count,
+    const char *format,
+    va_list argptr)
+{
+  // Forward to existing standards-compliant function. It may have be defined as
+  // a macro, so we need a wrapper function for bindgen to pick it up anyway.
+  return vsnprintf(buffer, count, format, argptr);
+}
+#endif
 
 // bindgen does not support non-trivial `#define` used for pointer constant. Use
 // statically defined constant as workaround for now.
 //
 // See https://github.com/rust-lang/rust-bindgen/issues/2426
-const void *const UA_EMPTY_ARRAY_SENTINEL_ = UA_EMPTY_ARRAY_SENTINEL;
+const void *const RS_EMPTY_ARRAY_SENTINEL = UA_EMPTY_ARRAY_SENTINEL;

--- a/wrapper.h
+++ b/wrapper.h
@@ -6,6 +6,8 @@
 #include <open62541/client_highlevel_async.h>
 #include <open62541/client_subscriptions.h>
 #include <open62541/plugin/log_stdout.h>
+#include <open62541/types.h>
+
 // Include with binding of `vsnprintf()` to simplify formatting of log messages.
 #include <stdio.h>
 
@@ -13,4 +15,12 @@
 // statically defined constant as workaround for now.
 //
 // See https://github.com/rust-lang/rust-bindgen/issues/2426
-extern const void *const UA_EMPTY_ARRAY_SENTINEL_;
+extern const void *const RS_EMPTY_ARRAY_SENTINEL;
+
+// Wrapper for `vsnprintf()` with normalized behavior across different platforms
+// such as Microsoft Windows.
+int RS_vsnprintf(
+    char *buffer,
+    size_t count,
+    const char *format,
+    va_list argptr);


### PR DESCRIPTION
## Description

This adds a custom wrapper to export `vsnprintf()` on Windows systems with C libraries older than the UCRT introduced in Visual Studio 2015 and Windows 10. On these systems, `vsnprintf()` is only available as `_vsnprintf()` and with a different runtime behavior.