### PR TITLE
Add back export logic of wrapper items

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,9 +109,9 @@ impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {
     }
 
     fn item_name(&self, original_item_name: &str) -> Option<String> {
-        // Rename pointer constant back to its original name. See `wrapper.c` for details.
-        if original_item_name == "RS_EMPTY_ARRAY_SENTINEL" {
-            return Some("UA_EMPTY_ARRAY_SENTINEL".to_owned());
+        // Rename our wrapped custom exports to their intended names.
+        if let Some(name) = original_item_name.strip_prefix("RS_") {
+            return Some(name.to_owned());
         }
         None
     }

--- a/build.rs
+++ b/build.rs
@@ -110,9 +110,6 @@ impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {
 
     fn item_name(&self, original_item_name: &str) -> Option<String> {
         // Rename our wrapped custom exports to their intended names.
-        if let Some(name) = original_item_name.strip_prefix("RS_") {
-            return Some(name.to_owned());
-        }
-        None
+        original_item_name.strip_prefix("RS_").map(str::to_owned)
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,8 @@
 use core::{ffi, ptr};
 
 use open62541_sys::{
-    va_list_, UA_Client_delete, UA_Client_new, UA_LogCategory, UA_LogLevel, UA_Logger,
-    UA_LoggerClearCallback_, UA_LoggerLogCallback_,
+    va_list_, vsnprintf_va_copy, vsnprintf_va_end, UA_Client_delete, UA_Client_new, UA_LogCategory,
+    UA_LogLevel, UA_Logger, UA_LoggerClearCallback_, UA_LoggerLogCallback_,
 };
 
 #[test]
@@ -48,4 +48,16 @@ fn logger_types() {
         context: ptr::null_mut(),
         clear,
     };
+}
+
+#[test]
+fn has_vsnprintf_va_copy() {
+    // Make sure that `vsnprintf_va_copy()` is available.
+    let _unused = vsnprintf_va_copy;
+}
+
+#[test]
+fn has_vsnprintf_va_end() {
+    // Make sure that `vsnprintf_va_end()` is available.
+    let _unused = vsnprintf_va_end;
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -3,11 +3,11 @@
 // Wrapper for `vsnprintf()` with normalized behavior across different platforms
 // such as Microsoft Windows.
 //
-// Other than the standard `vsnprintf()`, this function does not consume the passed
-// `va_list` argument! The caller is responsible for calling `vsnprintf_va_end()` on the
-// `va_list` argument eventually.
+// Other than the standard `vsnprintf()`, this function does not consume the
+// passed `va_list` argument! The caller is responsible for calling
+// `vsnprintf_va_end()` on the `va_list` argument eventually.
 #if defined(_MSC_VER) && _MSC_VER < 1900
-int vsnprintf_va_copy(
+int RS_vsnprintf_va_copy(
     char *buffer,
     size_t count,
     const char *format,
@@ -17,12 +17,14 @@ int vsnprintf_va_copy(
   // it does define a variant with slightly different behavior. We normalize the
   // differences as best we can.
   int result = -1;
-  if (count) {
+  if (count)
+  {
     va_list args_copied;
     va_copy(args_copied, args);
     result = _vsnprintf_s(buffer, count, _TRUNCATE, format, args_copied);
   }
-  if (result < 0) {
+  if (result < 0)
+  {
     va_list args_copied;
     va_copy(args_copied, args);
     result = _vscprintf(format, args_copied);
@@ -31,7 +33,7 @@ int vsnprintf_va_copy(
   return result;
 }
 #else
-int vsnprintf_va_copy(
+int RS_vsnprintf_va_copy(
     char *buffer,
     size_t count,
     const char *format,
@@ -47,7 +49,7 @@ int vsnprintf_va_copy(
 }
 #endif
 
-void vsnprintf_va_end(va_list args)
+void RS_vsnprintf_va_end(va_list args)
 {
   va_end(args);
 }

--- a/wrapper.h
+++ b/wrapper.h
@@ -8,9 +8,10 @@
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/types.h>
 
-// Include with binding of `vsnprintf()` and `va_list` functions to simplify formatting of log messages.
-#include <stdio.h>
+// Include with binding of `vsnprintf()` and `va_list` functions to simplify
+// formatting of log messages.
 #include <stdarg.h>
+#include <stdio.h>
 
 // bindgen does not support non-trivial `#define` used for pointer constant. Use
 // statically defined constant as workaround for now.
@@ -21,14 +22,16 @@ extern const void *const RS_EMPTY_ARRAY_SENTINEL;
 // Wrapper for `vsnprintf()` with normalized behavior across different platforms
 // such as Microsoft Windows.
 //
-// Other than the standard `vsnprintf()`, this implementation copies the `va_list`
-// argument before passing it along to allow repeated calls. The caller is responsible
-// to invoke `vsnprintf_va_end()` on the `va_list` argument eventually.
-int vsnprintf_va_copy(
+// Other than the standard `vsnprintf()`, this implementation copies the
+// `va_list` argument before passing it along to allow repeated calls. The
+// caller is responsible to invoke `vsnprintf_va_end()` on the `va_list`
+// argument eventually.
+int RS_vsnprintf_va_copy(
     char *buffer,
     size_t count,
     const char *format,
     va_list args);
 
-// Wrapper for `va_end()` that is supposed to be used with `vsnprintf_va_copy()`.
-void vsnprintf_va_end(va_list args);
+// Wrapper for `va_end()` that is supposed to be used with
+// `vsnprintf_va_copy()`.
+void RS_vsnprintf_va_end(va_list args);


### PR DESCRIPTION
## Description

This adds back the logic regarding the use of `RS_` prefixes to whitelist custom exported items. It also adds back the tests that check that our custom exports still appear in the generated bindings (even though they are treated as internal).