### PR TITLE
Fix export of `UA_EMPTY_ARRAY_SENTINEL` constant

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,8 @@
 use core::{ffi, ptr};
 
 use open62541_sys::{
-    va_list_, vsnprintf_va_copy, vsnprintf_va_end, UA_Client_delete, UA_Client_new, UA_LogCategory,
-    UA_LogLevel, UA_Logger, UA_LoggerClearCallback_, UA_LoggerLogCallback_,
+    va_list_, UA_Client_delete, UA_Client_new, UA_LogCategory, UA_LogLevel, UA_Logger,
+    UA_LoggerClearCallback_, UA_LoggerLogCallback_,
 };
 
 #[test]
@@ -51,13 +51,13 @@ fn logger_types() {
 }
 
 #[test]
-fn has_vsnprintf_va_copy() {
-    // Make sure that `vsnprintf_va_copy()` is available.
-    let _unused = vsnprintf_va_copy;
-}
+fn has_custom_exports() {
+    // Make sure that our custom exports (prefixed internally with `RS_`) are available under their
+    // expected names.
+    //
+    use open62541_sys::{vsnprintf_va_copy, vsnprintf_va_end, UA_EMPTY_ARRAY_SENTINEL};
 
-#[test]
-fn has_vsnprintf_va_end() {
-    // Make sure that `vsnprintf_va_end()` is available.
+    let _unused = vsnprintf_va_copy;
     let _unused = vsnprintf_va_end;
+    let _unused = unsafe { UA_EMPTY_ARRAY_SENTINEL };
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -58,4 +58,4 @@ void RS_vsnprintf_va_end(va_list args)
 // statically defined constant as workaround for now.
 //
 // See https://github.com/rust-lang/rust-bindgen/issues/2426
-const void *const RS_EMPTY_ARRAY_SENTINEL = UA_EMPTY_ARRAY_SENTINEL;
+const void *const RS_UA_EMPTY_ARRAY_SENTINEL = UA_EMPTY_ARRAY_SENTINEL;

--- a/wrapper.h
+++ b/wrapper.h
@@ -17,7 +17,7 @@
 // statically defined constant as workaround for now.
 //
 // See https://github.com/rust-lang/rust-bindgen/issues/2426
-extern const void *const RS_EMPTY_ARRAY_SENTINEL;
+extern const void *const RS_UA_EMPTY_ARRAY_SENTINEL;
 
 // Wrapper for `vsnprintf()` with normalized behavior across different platforms
 // such as Microsoft Windows.


### PR DESCRIPTION
## Description

This fixes a regression in #12 where we lost access to our wrapper for `UA_EMPTY_ARRAY_SENTINEL`.