### PR TITLE
GitHub CI: Use same build targets as in open62541 crate

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -27,23 +27,60 @@ env:
 jobs:
   run:
     strategy:
+      fail-fast: false # don't give up on the whole matrix if one variant fails
       matrix:
-        runner_os: [windows-latest, ubuntu-latest]
+        # Keep list of targets in sync with `test.yaml`.
         include:
-          # Add derived attribute `run_doctests`.
-          - run_doctests: true
-          - runner_os: windows-latest
-            # Doctests fill up disk storage on Windows, and we don't expect much
-            # different behavior anyway. It suffices to run them on Linux. Also,
-            # Windows runners are 2 times as expensive on GitHub.
-            run_doctests: false
+          - target: aarch64-apple-darwin
+            # M1 runner on macos-14
+            runner_os: macos-14
+            default_target: true
+            runnable: true
+          - target: armv7-unknown-linux-gnueabihf
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: false
+          - target: x86_64-apple-darwin
+            runner_os: macos-latest
+            default_target: true
+            runnable: true
+          - target: x86_64-unknown-linux-gnu
+            runner_os: ubuntu-latest
+            default_target: true
+            runnable: true
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: true
+          - target: x86_64-pc-windows-msvc
+            runner_os: windows-latest
+            default_target: true
+            runnable: true
 
     runs-on: ${{ matrix.runner_os }}
 
     steps:
+      - name: Install build tools for musl libc
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        # To avoid HTTP 404 when package index has been updated, we run `update` first.
+        run: >-
+          sudo apt -y update &&
+          sudo apt -y install musl-tools
+
+      - name: Install build tools for ARMv7
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        # To avoid HTTP 404 when package index has been updated, we run `update` first.
+        run: >-
+          sudo apt -y update &&
+          sudo apt -y install gcc-arm-linux-gnueabihf
+
       - name: Install Rust toolchain
         # Use latest stable Rust version.
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # This target also needs to be specified explicitly in every build step!
+          # Otherwise the default toolchain might be used unintentionally.
+          targets: ${{ matrix.target }}
 
       - name: Install Cargo helpers
         run: >-
@@ -59,12 +96,12 @@ jobs:
       - name: Cache Rust toolchain and build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          # The cache should not be shared between different workflows and jobs.
-          shared-key: ${{ github.workflow }}-${{ github.job }}
+          # The cache should not be shared between different workflows, jobs, and targets.
+          shared-key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.target }}
 
       - name: Update Rust to latest version
         run: >-
-          rustup update stable && rustup default stable
+          rustup update
 
       - name: Update crates to latest versions
         run: >-
@@ -73,10 +110,13 @@ jobs:
       - name: Build with feature combinations
         run: >-
           cargo hack --each-feature build --locked
+          --target ${{ matrix.target }}
 
       - name: Run tests (bins/lib/tests/examples) with feature combinations
+        if: matrix.runnable
         run: >-
           cargo hack --each-feature test --locked
+          --target ${{ matrix.target }}
           --bins --lib --tests --examples
 
       # Compile and run doctests, which have been excluded in the previous
@@ -95,7 +135,7 @@ jobs:
       # For now, we cannot cross-compile doctests and must always run them on
       # the runner's native platform.
       - name: Run doctests with all features enabled
-        if: ${{ matrix.run_doctests }}
+        if: matrix.default_target
         run: >-
           cargo test --locked --all-features
           --doc
@@ -104,3 +144,4 @@ jobs:
         # We allow dirty state here because it is only expected after update.
         run: >-
           cargo package --locked --all-features --allow-dirty
+          --target ${{ matrix.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,24 +24,61 @@ env:
 jobs:
   run:
     strategy:
+      fail-fast: false # don't give up on the whole matrix if one variant fails
       matrix:
-        runner_os: [windows-latest, ubuntu-latest]
+        # Keep list of targets in sync with `latest-dependencies.yaml`.
         include:
-          # Add derived attribute `run_doctests`.
-          - run_doctests: true
-          - runner_os: windows-latest
-            # Doctests fill up disk storage on Windows, and we don't expect much
-            # different behavior anyway. It suffices to run them on Linux. Also,
-            # Windows runners are 2 times as expensive on GitHub.
-            run_doctests: false
+          - target: aarch64-apple-darwin
+            # M1 runner on macos-14
+            runner_os: macos-14
+            default_target: true
+            runnable: true
+          - target: armv7-unknown-linux-gnueabihf
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: false
+          - target: x86_64-apple-darwin
+            runner_os: macos-latest
+            default_target: true
+            runnable: true
+          - target: x86_64-unknown-linux-gnu
+            runner_os: ubuntu-latest
+            default_target: true
+            runnable: true
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: true
+          - target: x86_64-pc-windows-msvc
+            runner_os: windows-latest
+            default_target: true
+            runnable: true
 
     runs-on: ${{ matrix.runner_os }}
 
     steps:
+      - name: Install build tools for musl libc
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        # To avoid HTTP 404 when package index has been updated, we run `update` first.
+        run: >-
+          sudo apt -y update &&
+          sudo apt -y install musl-tools
+
+      - name: Install build tools for ARMv7
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        # To avoid HTTP 404 when package index has been updated, we run `update` first.
+        run: >-
+          sudo apt -y update &&
+          sudo apt -y install gcc-arm-linux-gnueabihf
+
       - name: Install Rust toolchain
         # Use specific Rust version that is the minimum supported `rust-version`
         # (MSRV) from `Cargo.toml`.
         uses: dtolnay/rust-toolchain@1.70
+        with:
+          # This target also needs to be specified explicitly in every build step!
+          # Otherwise the default toolchain might be used unintentionally.
+          targets: ${{ matrix.target }}
 
       - name: Install Cargo helpers
         run: >-
@@ -57,16 +94,19 @@ jobs:
       - name: Cache Rust toolchain and build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          # The cache should not be shared between different workflows and jobs.
-          shared-key: ${{ github.workflow }}-${{ github.job }}
+          # The cache should not be shared between different workflows, jobs, and targets.
+          shared-key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.target }}
 
       - name: Build with feature combinations
         run: >-
           cargo hack --each-feature build --locked
+          --target ${{ matrix.target }}
 
       - name: Run tests (bins/lib/tests/examples) with feature combinations
+        if: matrix.runnable
         run: >-
           cargo hack --each-feature test --locked
+          --target ${{ matrix.target }}
           --bins --lib --tests --examples
 
       # Compile and run doctests, which have been excluded in the previous
@@ -85,7 +125,7 @@ jobs:
       # For now, we cannot cross-compile doctests and must always run them on
       # the runner's native platform.
       - name: Run doctests with all features enabled
-        if: ${{ matrix.run_doctests }}
+        if: matrix.default_target
         run: >-
           cargo test --locked --all-features
           --doc
@@ -93,3 +133,4 @@ jobs:
       - name: Build package with all features enabled
         run: >-
           cargo package --locked --all-features
+          --target ${{ matrix.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Rust toolchain
         # Use specific Rust version that is the minimum supported `rust-version`
         # (MSRV) from `Cargo.toml`.
-        uses: dtolnay/rust-toolchain@1.70
+        uses: dtolnay/rust-toolchain@1.72
         with:
           # This target also needs to be specified explicitly in every build step!
           # Otherwise the default toolchain might be used unintentionally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ name = "open62541-sys"
 version = "0.3.2"
 authors = ["HMI Project"]
 edition = "2021"
-# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.70, the
-# transitive dependency `home` of `bindgen` depends on it.
-rust-version = "1.70"
+# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.72 (the
+# linux-musl build fails with earlier versions).
+rust-version = "1.72"
 description = "Low-level, unsafe bindings for the C99 library open62541, an open source and free implementation of OPC UA (OPC Unified Architecture)."
 documentation = "https://docs.rs/open62541-sys"
 readme = "README.md"


### PR DESCRIPTION
## Description

This adds the same build targets for verifying builds on different platforms that were added in https://github.com/HMIProject/open62541/pull/33. For the linux-musl build, we have to upgrade the MSRV to 1.72.