### PR TITLE
Add note regarding `build.rs` to MSRV in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "open62541-sys"
 version = "0.3.2"
 authors = ["HMI Project"]
 edition = "2021"
-# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.72 (the
-# linux-musl build fails with earlier versions).
+# Keep the MSRV number here in sync with `test.yaml`/`build.rs`. We require Rust
+# 1.72 (the linux-musl build fails with earlier versions).
 rust-version = "1.72"
 description = "Low-level, unsafe bindings for the C99 library open62541, an open source and free implementation of OPC UA (OPC Unified Architecture)."
 documentation = "https://docs.rs/open62541-sys"

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn main() {
             is_bitfield: false,
             is_global: false,
         })
-        // Use explicit Rust target version that matches the entry in `Cargo.toml`.
+        // Use explicit Rust target version that matches or is older than the entry in `Cargo.toml`.
         .rust_target(bindgen::RustTarget::Stable_1_71)
         // Do not derive `Copy` because most of the data types are not copy-safe (they own memory by
         // pointers and need to be cloned manually to duplicate that memory).


### PR DESCRIPTION
## Description

This adjusts the comments regarding the Rust version used when invoking `bindgen` in `build.rs`. The version there should be more or less kept in sync with the MSRV in `Cargo.toml`.

We say "more or less" because bindgen does only track Rust versions that affect the ABI. When we have an MSRV that had no ABI changes, we leave the version in `build.rs` unchanged at the previous version (we must not use any newer version).