### PR TITLE
Explicitly include Linux headers to re-enable musl build

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -52,12 +52,10 @@ jobs:
             runner_os: ubuntu-latest
             default_target: true
             runnable: true
-          # TODO: Enable Linux musl build again when upstream issue has been
-          # resolved: https://github.com/open62541/open62541/issues/6360
-          # - target: x86_64-unknown-linux-musl
-          #   runner_os: ubuntu-latest
-          #   default_target: false
-          #   runnable: true
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: true
 
     runs-on: ${{ matrix.runner_os }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,12 +49,10 @@ jobs:
             runner_os: ubuntu-latest
             default_target: true
             runnable: true
-          # TODO: Enable Linux musl build again when upstream issue has been
-          # resolved: https://github.com/open62541/open62541/issues/6360
-          # - target: x86_64-unknown-linux-musl
-          #   runner_os: ubuntu-latest
-          #   default_target: false
-          #   runnable: true
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-latest
+            default_target: false
+            runnable: true
 
     runs-on: ${{ matrix.runner_os }}
 


### PR DESCRIPTION
## Description

This is a work-around to temporarily enable [musl libc](https://www.musl-libc.org) builds again. It is not ideal because we manually add include paths to Linux headers from the build system's environment which have been deliberately omitted from the musl include directory.

The musl FAQs [warn against the use of kernel headers](https://wiki.musl-libc.org/faq#Q:-Why-am-I-getting-), so we will likely keep this work-around only until open62541 allows building without features that require those headers, at least when targeting musl environments.

See https://github.com/open62541/open62541/issues/6360