### PR TITLE
Upgrade open62541 to released version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to release 1.4.0 of open62541 version 1.4.
+
 ## [0.4.0-pre.3] - 2024-04-04
 
 [0.4.0-pre.3]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.2...v0.4.0-pre.3


### PR DESCRIPTION
## Description

This upgrades the contained source of open62541 to the released version [1.4.0](https://github.com/open62541/open62541/releases/tag/v1.4.0).