### PR TITLE
Upgrade to open62541 version 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to release [1.4.3](https://github.com/open62541/open62541/releases/tag/v1.4.3) of
+  open62541 version 1.4.
+
 ## [0.4.0] - 2024-07-12
 
 [0.4.0]: https://github.com/HMIProject/open62541-sys/compare/v0.3.3...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - 2024-07-12
 
-[0.4.0]: https://github.com/HMIProject/open62541-sys/compare/v0.3.3...v0.4.0
-
 ### Changed
 
 - Breaking: Upgrade to open62541 version 1.4. While mostly compatible, this introduces some API
@@ -24,16 +22,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0-pre.6] - 2024-07-04
 
-[0.4.0-pre.6]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.5...v0.4.0-pre.6
-
 ### Changed
 
 - Upgrade to release [1.4.2](https://github.com/open62541/open62541/releases/tag/v1.4.2) of
   open62541 version 1.4.
 
 ## [0.4.0-pre.5] - 2024-05-30
-
-[0.4.0-pre.5]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.4...v0.4.0-pre.5
 
 ### Changed
 
@@ -42,16 +36,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0-pre.4] - 2024-04-29
 
-[0.4.0-pre.4]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.3...v0.4.0-pre.4
-
 ### Changed
 
 - Upgrade to release [1.4.0](https://github.com/open62541/open62541/releases/tag/v1.4.0) of
   open62541 version 1.4.
 
 ## [0.4.0-pre.3] - 2024-04-04
-
-[0.4.0-pre.3]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.2...v0.4.0-pre.3
 
 ### Changed
 
@@ -61,15 +51,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0-pre.2] - 2024-03-27
 
-[0.4.0-pre.2]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.1...v0.4.0-pre.2
-
 ### Changed
 
 - Add work-around to re-enable builds for [musl libc](https://www.musl-libc.org) environment.
 
 ## [0.4.0-pre.1] - 2024-03-26
-
-[0.4.0-pre.1]: https://github.com/HMIProject/open62541-sys/compare/v0.3.3...v0.4.0-pre.1
 
 ### Changed
 
@@ -79,15 +65,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.3] - 2024-02-12
 
-[0.3.3]: https://github.com/HMIProject/open62541-sys/compare/v0.3.2...v0.3.3
-
 ### Fixed
 
 - Avoid unnecessary rebuilds when only rebuilt files have changed.
 
 ## [0.3.2] - 2024-01-23
-
-[0.3.2]: https://github.com/HMIProject/open62541-sys/compare/v0.3.1...v0.3.2
 
 ### Fixed
 
@@ -95,15 +77,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.1] - 2024-01-23
 
-[0.3.1]: https://github.com/HMIProject/open62541-sys/compare/v0.3.0...v0.3.1
-
 ### Fixed
 
 - Export `vsnprintf_va_copy()` and `vsnprintf_va_end()` as intended.
 
 ## [0.3.0] - 2024-01-23
-
-[0.3.0]: https://github.com/HMIProject/open62541-sys/compare/v0.2.2...v0.3.0
 
 ### Changed
 
@@ -112,8 +90,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.2] - 2024-01-22
 
-[0.2.2]: https://github.com/HMIProject/open62541-sys/compare/v0.2.1...v0.2.2
-
 ### Changed
 
 - Add binding for `va_end()`, adjust behavior of `vsnprintf()` to call `va_copy()` internally
@@ -121,16 +97,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.1] - 2024-01-19
 
-[0.2.1]: https://github.com/HMIProject/open62541-sys/compare/v0.2.0...v0.2.1
-
 ### Fixed
 
 - Add wrapper for `vsnprintf()` to support older C library versions (before UCRT in Visual Studio
   2015 and Windows 10).
 
 ## [0.2.0] - 2024-01-17
-
-[0.2.0]: https://github.com/HMIProject/open62541-sys/compare/v0.1.3...v0.2.0
 
 ### Added
 
@@ -143,8 +115,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.3] - 2024-01-12
 
-[0.1.3]: https://github.com/HMIProject/open62541-sys/releases/tag/v0.1.3
-
 ### Added
 
 - First public release.
+
+[0.4.0]: https://github.com/HMIProject/open62541-sys/compare/v0.3.3...v0.4.0
+[0.4.0-pre.6]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.5...v0.4.0-pre.6
+[0.4.0-pre.5]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.4...v0.4.0-pre.5
+[0.4.0-pre.4]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.3...v0.4.0-pre.4
+[0.4.0-pre.3]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.2...v0.4.0-pre.3
+[0.4.0-pre.2]: https://github.com/HMIProject/open62541-sys/compare/v0.4.0-pre.1...v0.4.0-pre.2
+[0.4.0-pre.1]: https://github.com/HMIProject/open62541-sys/compare/v0.3.3...v0.4.0-pre.1
+[0.3.3]: https://github.com/HMIProject/open62541-sys/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/HMIProject/open62541-sys/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/HMIProject/open62541-sys/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/HMIProject/open62541-sys/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/HMIProject/open62541-sys/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/HMIProject/open62541-sys/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/HMIProject/open62541-sys/compare/v0.1.3...v0.2.0
+[0.1.3]: https://github.com/HMIProject/open62541-sys/releases/tag/v0.1.3


### PR DESCRIPTION
## Description

This upgrades the bundled dependency on open62541 to the latest released version [1.4.3](https://github.com/open62541/open62541/releases/tag/v1.4.3).