### PR TITLE
Upgrade to open62541 version 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to open62541 version [1.4.4](https://github.com/open62541/open62541/releases/tag/v1.4.4).
+
 ## [0.4.1] - 2024-07-29
 
 ### Changed
 
-- Upgrade to release [1.4.3](https://github.com/open62541/open62541/releases/tag/v1.4.3) of
-  open62541 version 1.4.
+- Upgrade to open62541 version [1.4.3](https://github.com/open62541/open62541/releases/tag/v1.4.3).
 
 ## [0.4.0] - 2024-07-12
 
@@ -24,22 +29,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade to release [1.4.2](https://github.com/open62541/open62541/releases/tag/v1.4.2) of
-  open62541 version 1.4.
+- Upgrade to open62541 version [1.4.2](https://github.com/open62541/open62541/releases/tag/v1.4.2).
 
 ## [0.4.0-pre.5] - 2024-05-30
 
 ### Changed
 
-- Upgrade to release [1.4.1](https://github.com/open62541/open62541/releases/tag/v1.4.1) of
-  open62541 version 1.4.
+- Upgrade to open62541 version [1.4.1](https://github.com/open62541/open62541/releases/tag/v1.4.1).
 
 ## [0.4.0-pre.4] - 2024-04-29
 
 ### Changed
 
-- Upgrade to release [1.4.0](https://github.com/open62541/open62541/releases/tag/v1.4.0) of
-  open62541 version 1.4.
+- Upgrade to open62541 version [1.4.0](https://github.com/open62541/open62541/releases/tag/v1.4.0).
 
 ## [0.4.0-pre.3] - 2024-04-04
 


### PR DESCRIPTION
## Description

This upgrades the bundled dependency on open62541 to the latest released version [1.4.4](https://github.com/open62541/open62541/releases/tag/v1.4.4).