### PR TITLE
Add unsafe to extern blocks for Rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "bindgen",
  "cc",
  "cmake",
+ "version_check",
 ]
 
 [[package]]
@@ -316,6 +317,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ include = [
 bindgen = { version = "0.69.4", features = ["experimental"] }
 cc = "1.0.83"
 cmake = "0.1.50"
+version_check = "0.9.5"
 
 [lints.rust]
 future_incompatible = { level = "warn", priority = -1 }

--- a/build.rs
+++ b/build.rs
@@ -140,7 +140,7 @@ fn main() {
     // Until <https://github.com/rust-lang/rust-bindgen/issues/2901> is resolved, we replace `extern
     // "C"` with `unsafe extern "C"` manually here. Remove this when `bindgen` is able to do it.
     if version_check::is_min_version("1.82.0") == Some(true) {
-        // We can only use `extern unsafe` starting with Rust 1.82.0. See
+        // We can only use `unsafe extern` starting with Rust 1.82.0. See
         // <https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern>.
         replace_in_file(
             &out_bindings_rs,

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ const LIB_EXT: &str = "open62541-ext";
 /// See also [`LEGACY_EXTERN_REPLACEMENT`].
 const LEGACY_EXTERN_PATTERN: &str = r#"extern "C" {"#;
 
-/// Pattern to replace for compatibility with Edition 2024.
+/// Replacement to use for compatibility with Edition 2024.
 ///
 /// See also [`LEGACY_EXTERN_PATTERN`].
 const LEGACY_EXTERN_REPLACEMENT: &str = r#"unsafe extern "C" {"#;

--- a/build.rs
+++ b/build.rs
@@ -213,7 +213,7 @@ impl bindgen::callbacks::ParseCallbacks for CustomCallbacks {
 /// Replaces all occurrences of pattern in file.
 ///
 /// Note that this is not particularly efficient because it reads the entire file into memory before
-/// witing it back. Care should be taken when operating on large files.
+/// writing it back. Care should be taken when operating on large files.
 fn replace_in_file(path: &Path, pattern: &str, replacement: &str) -> io::Result<()> {
     let buf = io::read_to_string(File::open(path)?)?;
 

--- a/build.rs
+++ b/build.rs
@@ -139,8 +139,12 @@ fn main() {
 
     // Until <https://github.com/rust-lang/rust-bindgen/issues/2901> is resolved, we replace `extern
     // "C"` with `unsafe extern "C"` manually here. Remove this when `bindgen` is able to do it.
-    replace_in_file(&out_bindings_rs, EXTERN_PATTERN, UNSAFE_EXTERN_REPLACEMENT)
-        .expect("should add unsafe to extern statements");
+    if version_check::is_min_version("1.82.0") == Some(true) {
+        // We can only use `extern unsafe` starting with Rust 1.82.0. See
+        // <https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern>.
+        replace_in_file(&out_bindings_rs, EXTERN_PATTERN, UNSAFE_EXTERN_REPLACEMENT)
+            .expect("should add unsafe to extern statements");
+    }
 
     // Build `extern.c` and our custom `wrapper.c` that both hold additional helpers that we want to
     // link in addition to the base `open62541` library.

--- a/build.rs
+++ b/build.rs
@@ -20,13 +20,13 @@ const LIB_EXT: &str = "open62541-ext";
 
 /// Pattern to search for compatibility with Edition 2024.
 ///
-/// See also [`UNSAFE_EXTERN_REPLACEMENT`].
-const EXTERN_PATTERN: &str = r#"extern "C" {"#;
+/// See also [`LEGACY_EXTERN_REPLACEMENT`].
+const LEGACY_EXTERN_PATTERN: &str = r#"extern "C" {"#;
 
 /// Pattern to replace for compatibility with Edition 2024.
 ///
-/// See also [`EXTERN_PATTERN`].
-const UNSAFE_EXTERN_REPLACEMENT: &str = r#"unsafe extern "C" {"#;
+/// See also [`LEGACY_EXTERN_PATTERN`].
+const LEGACY_EXTERN_REPLACEMENT: &str = r#"unsafe extern "C" {"#;
 
 fn main() {
     let src = env::current_dir().expect("should get current directory");
@@ -142,8 +142,12 @@ fn main() {
     if version_check::is_min_version("1.82.0") == Some(true) {
         // We can only use `extern unsafe` starting with Rust 1.82.0. See
         // <https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern>.
-        replace_in_file(&out_bindings_rs, EXTERN_PATTERN, UNSAFE_EXTERN_REPLACEMENT)
-            .expect("should add unsafe to extern statements");
+        replace_in_file(
+            &out_bindings_rs,
+            LEGACY_EXTERN_PATTERN,
+            LEGACY_EXTERN_REPLACEMENT,
+        )
+        .expect("should add unsafe to extern statements");
     }
 
     // Build `extern.c` and our custom `wrapper.c` that both hold additional helpers that we want to


### PR DESCRIPTION
## Description

This replaces the declaration of `extern "C"` blocks with `unsafe extern "C"` as will be required by Rust 2024. Remove this when https://github.com/rust-lang/rust-bindgen/issues/2901 is merged and [bindgen](https://crates.io/crates/bindgen) can generate these blocks automatically as required.