### PR TITLE
Update pre-commit config and hooks

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,7 +9,8 @@ config:
   # The same headline in different nested sections is okay (and necessary for
   # CHANGELOG.md).
   no-duplicate-heading:
-    allow_different_nesting: true
+    # https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
+    siblings_only: true
 
 # Fix any fixable errors.
 fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 default_stages:
   # Prevent that hooks run twice, triggered by both
   # the Git commit-msg and the pre-commit hook.
-  - commit
+  - pre-commit
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-json
@@ -22,19 +22,24 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.11.0
+    rev: v0.15.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         args: [--ignore-words=.codespellignore]
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.27.1
+    rev: 0.29.4
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+      - id: taplo-lint
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
@@ -48,7 +53,11 @@ repos:
       - id: fmt
         args: [--all, --]
       - id: clippy
+        name: clippy --all-features
         args: [--locked, --all-features, --all-targets, --, -D, warnings]
+      - id: clippy
+        name: clippy --no-default-features
+        args: [--locked, --no-default-features, --all-targets, --, -D, warnings]
   - repo: local
     hooks:
       - id: cargo-doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,36 +15,36 @@ license = "MPL-2.0"
 keywords = ["opcua", "plc", "automation", "hardware", "protocol"]
 categories = ["network-programming", "embedded", "external-ffi-bindings"]
 include = [
-    "CHANGELOG.md",
-    "README.md",
-    "build.rs",
-    "src/",
-    "wrapper.c",
-    "wrapper.h",
-    "open62541/**/CMakeLists.txt",
-    "open62541/arch/",
-    "open62541/deps/",
-    # Exclude large dependencies that we do not use. If build fails, check first
-    # if one of these is missing.
-    "!open62541/deps/mdnsd/",
-    "!open62541/deps/mqtt-c/",
-    "!open62541/deps/nodesetLoader/",
-    # We do not include OPC UA NodeSets. They are required when implementing OPC
-    # UA servers: the `nodeset_compiler` tool uses these definitions to generate
-    # custom C and header files that can be used in a server implementation. See
-    # `open62541/doc/nodeset_compiler.rst` for details.
-    "!open62541/deps/ua-nodeset/",
-    # We require this file only to make sure the directory `ua-nodeset/` exists.
-    "open62541/deps/ua-nodeset/readme.md",
-    "open62541/doc/conf.py",
-    "open62541/include/open62541/",
-    "open62541/plugins/",
-    "open62541/tools/certs/",
-    "open62541/tools/cmake/",
-    "open62541/tools/generate_*.py",
-    "open62541/tools/nodeset_compiler/",
-    "open62541/tools/open62541.pc.in",
-    "open62541/tools/schema/",
+  "CHANGELOG.md",
+  "README.md",
+  "build.rs",
+  "src/",
+  "wrapper.c",
+  "wrapper.h",
+  "open62541/**/CMakeLists.txt",
+  "open62541/arch/",
+  "open62541/deps/",
+  # Exclude large dependencies that we do not use. If build fails, check first
+  # if one of these is missing.
+  "!open62541/deps/mdnsd/",
+  "!open62541/deps/mqtt-c/",
+  "!open62541/deps/nodesetLoader/",
+  # We do not include OPC UA NodeSets. They are required when implementing OPC
+  # UA servers: the `nodeset_compiler` tool uses these definitions to generate
+  # custom C and header files that can be used in a server implementation. See
+  # `open62541/doc/nodeset_compiler.rst` for details.
+  "!open62541/deps/ua-nodeset/",
+  # We require this file only to make sure the directory `ua-nodeset/` exists.
+  "open62541/deps/ua-nodeset/readme.md",
+  "open62541/doc/conf.py",
+  "open62541/include/open62541/",
+  "open62541/plugins/",
+  "open62541/tools/certs/",
+  "open62541/tools/cmake/",
+  "open62541/tools/generate_*.py",
+  "open62541/tools/nodeset_compiler/",
+  "open62541/tools/open62541.pc.in",
+  "open62541/tools/schema/",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
## Description

This updates the [pre-commit](https://pre-commit.com) repos and makes sure to use the proper (non-deprecated) name for the Markdown config. It also adds checks for TOML formatting.