### PR TITLE
Include open62541 headers required for encryption

### DIFF
--- a/wrapper.h
+++ b/wrapper.h
@@ -6,6 +6,16 @@
 #include <open62541/client_subscriptions.h>
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
+#include <open62541/plugin/log.h>
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/plugin/pki.h>
+#include <open62541/plugin/pki_default.h>
+#include <open62541/plugin/securitypolicy.h>
+
+// Include files that are only available (by CMake) with certain flags.
+#ifdef UA_ENABLE_ENCRYPTION
+#include <open62541/plugin/securitypolicy_default.h>
+#endif
 
 // Include with binding of `vsnprintf()` and `va_list` functions to simplify
 // formatting of log messages.


### PR DESCRIPTION
## Description

This is a follow-up to #39 and includes additional bindings, some of which are only available with feature flag `mbedtls`.