### PR TITLE
Include headers for access control in bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Include bindings for functions from header files `plugin/accesscontrol.h`,
+  `plugin/accesscontrol_default.h`.
+
 ### Changed
 
 - Upgrade to build dependency bindgen version

--- a/wrapper.h
+++ b/wrapper.h
@@ -6,6 +6,8 @@
 #include <open62541/client_subscriptions.h>
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
+#include <open62541/plugin/accesscontrol.h>
+#include <open62541/plugin/accesscontrol_default.h>
 #include <open62541/plugin/log.h>
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pki.h>


### PR DESCRIPTION
## Description

This adds bindings for functions defined in `plugin/accesscontrol.h`, `plugin/accesscontrol_default.h`. We require them to implement authentication and authorization in the server.