### PR TITLE
Include headers for certificate creation in bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Include bindings for functions from header files `plugin/create_certificate.h` (when feature flag
+  `mbedtls` is enabled).
+
 ## [0.4.7] - 2024-11-25
 
 ### Changed

--- a/wrapper.h
+++ b/wrapper.h
@@ -16,6 +16,7 @@
 
 // Include files that are only available (by CMake) with certain flags.
 #ifdef UA_ENABLE_ENCRYPTION
+#include <open62541/plugin/create_certificate.h>
 #include <open62541/plugin/securitypolicy_default.h>
 #endif
 


### PR DESCRIPTION
## Description

This is a follow-up to #43 where support for creating certificates with Mbed TLS was [added](https://github.com/open62541/open62541/pull/6145).[^1] We include the bindings now as well to facilitate certificate creation.

[^1]: Until then, `UA_CreateCertificate()` was only available with OpenSSL.