### PR TITLE
Fix: Cross-compilation error with MinGW due to incorrect library case

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,9 +70,9 @@ fn main() {
     let dst_lib = dst.join(CMAKE_LIB);
 
     if matches!(env::var("CARGO_CFG_TARGET_OS"), Ok(os) if os == "windows") {
-        // We require the `Iphlpapi` library on Windows builds to avoid errors (regarding the use of
+        // We require the `iphlpapi` library on Windows builds to avoid errors (regarding the use of
         // `if_nametoindex`, see https://github.com/open62541/open62541/issues/5622).
-        println!("cargo:rustc-link-lib=Iphlpapi");
+        println!("cargo:rustc-link-lib=iphlpapi");
     }
 
     println!("cargo:rustc-link-search={}", dst_lib.display());


### PR DESCRIPTION
When cross-compiling on Linux for Windows using MinGW, the following linker error was encountered:

`/usr/bin/x86_64-w64-mingw32-ld: cannot find -lIphlpapi: No such file or directory`

This occurs because Linux filesystems are case-sensitive, and the linker cannot find libIphlpapi.a. The actual filename is libiphlpapi.a (all lowercase), which works on Windows due to its case-insensitive filesystem.

This change corrects the library name casing, ensuring that cross-compilation on Linux succeeds while maintaining compatibility on Windows.
