### PR TITLE
Resolve MBEDTLS library path issues when cross-compiling with `cross`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -304,7 +304,13 @@ fn build_open62541(src: PathBuf, encryption: Option<&EncryptionDst>) -> PathBuf 
             // Skip auto-detection and use explicit folders from `mbedtls` build.
             cmake
                 .define("MBEDTLS_FOLDER_INCLUDE", dst.join(CMAKE_INCLUDE))
-                .define("MBEDTLS_FOLDER_LIBRARY", dst.join(CMAKE_LIB));
+                .define("MBEDTLS_FOLDER_LIBRARY", dst.join(CMAKE_LIB))
+                .define("MBEDCRYPTO_INCLUDE_DIRS", dst.join(CMAKE_INCLUDE))
+                .define("MBEDCRYPTO_LIBRARY", dst.join(CMAKE_LIB))
+                .define("MBEDTLS_INCLUDE_DIRS", dst.join(CMAKE_INCLUDE))
+                .define("MBEDTLS_LIBRARY", dst.join(CMAKE_LIB))
+                .define("MBEDX509_INCLUDE_DIRS", dst.join(CMAKE_INCLUDE))
+                .define("MBEDX509_LIBRARY", dst.join(CMAKE_LIB));
             "MBEDTLS"
         }
         Some(EncryptionDst::OpenSsl { .. }) => "OPENSSL",


### PR DESCRIPTION
For cross-compilation, the [`cross`](https://github.com/cross-rs/cross/) tool is commonly used.

However, `cross` sets the following CMake flags during cross-compilation (ref: https://github.com/cross-rs/cross/issues/1291 , https://github.com/cross-rs/cross/issues/1270 , https://github.com/cross-rs/cross/issues/1180 ):

```
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
```
As a result, when using  `MBEDTLS_FOLDER_*` variables, [`find_library`](https://github.com/open62541/open62541/blob/55d0b902f7a2bbe7fc40748fa312c092f1ead649/tools/cmake/FindMbedTLS.cmake#L17-L19) and `find_include` may fail because it searches under `${CMAKE_FIND_ROOT_PATH}/${MBEDTLS_FOLDER_*}` (e.g., `/usr/local/arm-linux-musleabihf/target/armv7-unknown-linux-musleabihf/debug/build/open62541-sys-99e9fe8851f209a1/out/lib/`). This behavior can prevent find_package from locating the required `MBEDTLS` libraries or headers as expected.

To resolve this, setting related variables like `MBEDTLS_LIBRARY`  directly is a straightforward solution.
