### PR TITLE
test: Disconnect client before deletion

### DIFF
--- a/tests/server_client.rs
+++ b/tests/server_client.rs
@@ -10,13 +10,13 @@ use std::{
 };
 
 use open62541_sys::{
-    UA_Array_copy, UA_Array_delete, UA_Client, UA_Client_connect, UA_Client_delete, UA_Client_new,
-    UA_Client_readValueAttribute, UA_DataType, UA_Server, UA_ServerConfig, UA_Server_delete,
-    UA_Server_getConfig, UA_Server_new, UA_Server_run_iterate, UA_Server_run_shutdown,
-    UA_Server_run_startup, UA_String, UA_String_clear, UA_String_delete, UA_String_fromChars,
-    UA_String_new, UA_Variant, UA_Variant_delete, UA_Variant_new, UA_print, UA_NODEID_NUMERIC,
-    UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME, UA_STATUSCODE_GOOD, UA_TYPES,
-    UA_TYPES_STRING, UA_TYPES_VARIANT,
+    UA_Array_copy, UA_Array_delete, UA_Client, UA_Client_connect, UA_Client_delete,
+    UA_Client_disconnect, UA_Client_new, UA_Client_readValueAttribute, UA_DataType, UA_Server,
+    UA_ServerConfig, UA_Server_delete, UA_Server_getConfig, UA_Server_new, UA_Server_run_iterate,
+    UA_Server_run_shutdown, UA_Server_run_startup, UA_String, UA_String_clear, UA_String_delete,
+    UA_String_fromChars, UA_String_new, UA_Variant, UA_Variant_delete, UA_Variant_new, UA_print,
+    UA_NODEID_NUMERIC, UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME, UA_STATUSCODE_GOOD,
+    UA_TYPES, UA_TYPES_STRING, UA_TYPES_VARIANT,
 };
 
 #[test]
@@ -113,6 +113,10 @@ fn run_client(url: &str, f: impl FnOnce(*mut UA_Client)) {
     assert_eq!(res, UA_STATUSCODE_GOOD, "connect client");
 
     f(client);
+
+    // Disconnect client.
+    let res = unsafe { UA_Client_disconnect(client) };
+    assert_eq!(res, UA_STATUSCODE_GOOD, "disconnect client");
 
     // Clean up client.
     unsafe { UA_Client_delete(client) };


### PR DESCRIPTION
This makes sure to disconnect the client first before deleting it. This makes no difference (because disconnect is invoked by `UA_Client_delete()` anyway), but it is cleaner. Inspired by https://github.com/HMIProject/open62541/pull/259#discussion_r2310063000.