### PR TITLE
ci: Replace Ubuntu 22.04 with 26.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,22 +39,22 @@ jobs:
             runner_os: macos-26
 
           - target: aarch64-unknown-linux-gnu
-            runner_os: ubuntu-22.04-arm
-          - target: aarch64-unknown-linux-gnu
             runner_os: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-gnu
+            runner_os: ubuntu-26.04-arm
 
           - target: aarch64-unknown-linux-musl
-            runner_os: ubuntu-22.04-arm
-          - target: aarch64-unknown-linux-musl
             runner_os: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-musl
+            runner_os: ubuntu-26.04-arm
 
           - target: aarch64-pc-windows-msvc
             runner_os: windows-11-arm
 
           - target: armv7-unknown-linux-gnueabihf
-            runner_os: ubuntu-22.04
-          - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-24.04
+          - target: armv7-unknown-linux-gnueabihf
+            runner_os: ubuntu-26.04
 
           - target: x86_64-apple-darwin
             runner_os: macos-14
@@ -69,14 +69,14 @@ jobs:
             runner_os: windows-2025
 
           - target: x86_64-unknown-linux-gnu
-            runner_os: ubuntu-22.04
-          - target: x86_64-unknown-linux-gnu
             runner_os: ubuntu-24.04
+          - target: x86_64-unknown-linux-gnu
+            runner_os: ubuntu-26.04
 
           - target: x86_64-unknown-linux-musl
-            runner_os: ubuntu-22.04
-          - target: x86_64-unknown-linux-musl
             runner_os: ubuntu-24.04
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-26.04
 
     runs-on: ${{ matrix.runner_os }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,8 +53,10 @@ jobs:
 
           - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-24.04
-          - target: armv7-unknown-linux-gnueabihf
-            runner_os: ubuntu-26.04
+          # Build on Ubuntu 26.04 fails: <https://github.com/Mbed-TLS/mbedtls/issues/9875>
+          # TODO: Re-enable when fixed.
+          #- target: armv7-unknown-linux-gnueabihf
+          #  runner_os: ubuntu-26.04
 
           - target: x86_64-apple-darwin
             runner_os: macos-15-intel


### PR DESCRIPTION
Retire Ubuntu 22.04 CI builds and replace them with Ubuntu 26.04.

The ARM v7 CI build on Ubuntu 26.04 remains disabled for now.