### PR TITLE
Fix Linux musl and aarch64 builds

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -36,9 +36,11 @@ jobs:
           - target: aarch64-apple-darwin
             runner_os: macos-latest
           - target: aarch64-unknown-linux-gnu
-            runner_os: ubuntu-latest
+            # There is no ubuntu-latest-arm runner.
+            runner_os: ubuntu-26.04-arm
           - target: aarch64-unknown-linux-musl
-            runner_os: ubuntu-latest
+            # There is no ubuntu-latest-arm runner.
+            runner_os: ubuntu-26.04-arm
           - target: aarch64-pc-windows-msvc
             # There is no windows-latest-arm runner.
             runner_os: windows-11-arm
@@ -113,9 +115,6 @@ jobs:
           build --locked
 
       - name: Run tests (bins/lib/tests/examples) with feature combinations
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo hack --each-feature
           test --locked
@@ -128,9 +127,6 @@ jobs:
       # certain features only for some doctests, so we run them without
       # `cargo-hack`.
       - name: Run doctests with all features enabled
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo test
           --locked --all-features

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -136,9 +136,6 @@ jobs:
           build --locked
 
       - name: Run tests (bins/lib/tests/examples) with feature combinations
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo hack --each-feature
           test --locked
@@ -151,9 +148,6 @@ jobs:
       # certain features only for some doctests, so we run them without
       # `cargo-hack`.
       - name: Run doctests with all features enabled
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo test
           --locked --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Linux musl and aarch64 builds.
+
 ## [0.5.5] - 2026-07-02
 
 ### Changed

--- a/build.rs
+++ b/build.rs
@@ -75,6 +75,19 @@ fn main() {
         encryption_dst.rustc_link_lib();
     }
 
+    if matches!(env::var("CARGO_CFG_TARGET_ENV"), Ok(env) if env == "musl") {
+        // Link `libgcc` to resolve `__gcc_personality_v0`. GCC-compiled `open62541` C files that
+        // use GCC's cleanup attribute emit a `DW.ref.__gcc_personality_v0` reference in a
+        // `.data.rel.local` section. This symbol lives in `libgcc.a`, which is part of the GCC
+        // runtime for the musl cross-toolchain. Rust's musl linker passes `-nodefaultlibs` and
+        // does not include `libgcc` automatically.
+        //
+        // IMPORTANT: This directive must appear *after* `cargo:rustc-link-lib=open62541` so that
+        // the static linker processes `-lgcc` after `-lopen62541`. With static archive linking,
+        // the library providing a symbol must be listed *after* the library that references it.
+        println!("cargo:rustc-link-lib=gcc");
+    }
+
     let out = PathBuf::from(env::var("OUT_DIR").expect("should have OUT_DIR"));
 
     // Get derived paths relative to `out`.


### PR DESCRIPTION
Backports of fixes from the oen62541 v1.5 branch.